### PR TITLE
Add MicroEngine unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2024"
 [dependencies]
 tracing = "*"
 chrono = "*"
-tokio = {version = "*", features = ["sync", "macros"]}
+tokio = {version = "*", features = ["sync", "macros", "rt"]}
 rust_decimal = "*"
 cross-calculations = { git = "https://github.com/my-cfd-platform/cross-calculations.git", tag = "0.1.8" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,3 +203,155 @@ pub enum MicroEngineError {
     PositionNotFound,
     AccountSettingsNotFound(String),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::TradingGroupInstrumentSettings;
+    use std::collections::{HashMap, HashSet};
+
+    fn sample_settings() -> MicroEngineTradingGroupSettings {
+        let mut instruments = HashMap::new();
+        instruments.insert(
+            "EURUSD".to_string(),
+            TradingGroupInstrumentSettings {
+                digits: 5,
+                max_leverage: None,
+                markup_settings: None,
+            },
+        );
+
+        MicroEngineTradingGroupSettings {
+            id: "G1".to_string(),
+            hedge_coef: None,
+            instruments,
+        }
+    }
+
+    fn sample_account() -> MicroEngineAccount {
+        MicroEngineAccount {
+            id: "ACC1".to_string(),
+            trader_id: "TR1".to_string(),
+            trading_group: "G1".to_string(),
+            balance: 1000.0,
+            leverage: 100.0,
+            margin: 0.0,
+            equity: 0.0,
+            free_margin: 0.0,
+            margin_level: 0.0,
+        }
+    }
+
+    fn sample_instrument() -> MicroEngineInstrument {
+        MicroEngineInstrument {
+            id: "EURUSD".to_string(),
+            base: "EUR".to_string(),
+            quote: "USD".to_string(),
+        }
+    }
+
+    fn sample_bidask() -> MicroEngineBidask {
+        MicroEngineBidask {
+            id: "EURUSD".to_string(),
+            bid: 1.0,
+            ask: 1.1,
+            base: "EUR".to_string(),
+            quote: "USD".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_initialize_and_query() {
+        let account = sample_account();
+        let settings = sample_settings();
+        let instrument = sample_instrument();
+        let bidask = sample_bidask();
+
+        let collaterals = HashSet::from(["USD".to_string()]);
+
+        let (engine, errors) = MicroEngine::initialize(
+            vec![account.clone()],
+            Vec::<MicroEnginePosition>::new(),
+            vec![settings],
+            collaterals,
+            vec![instrument],
+            vec![bidask],
+        );
+        assert!(errors.is_empty());
+
+        let accounts = engine
+            .query_account_cache(|cache| cache.get_all_accounts().into_iter().cloned().collect())
+            .await;
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].id, account.id);
+    }
+
+    fn sample_position() -> MicroEnginePosition {
+        let price = sample_bidask();
+        MicroEnginePosition {
+            id: "POS1".to_string(),
+            trader_id: "TR1".to_string(),
+            account_id: "ACC1".to_string(),
+            base: "EUR".to_string(),
+            quote: "USD".to_string(),
+            collateral: "USD".to_string(),
+            asset_pair: "EURUSD".to_string(),
+            lots_amount: 1.0,
+            contract_size: 1.0,
+            is_buy: true,
+            pl: 0.0,
+            commission: 0.0,
+            open_bidask: price.clone(),
+            active_bidask: price.clone(),
+            margin_bidask: price.clone(),
+            profit_bidask: MicroEngineBidask::create_blank(),
+            profit_price_assets_subscriptions: HashSet::new(),
+            swaps_sum: 0.0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_price_update_and_recalc() {
+        let account = sample_account();
+        let settings = sample_settings();
+        let instrument = sample_instrument();
+        let bidask = sample_bidask();
+
+        let collaterals = HashSet::from(["USD".to_string()]);
+
+        let (engine, errors) = MicroEngine::initialize(
+            vec![account.clone()],
+            Vec::<MicroEnginePosition>::new(),
+            vec![settings],
+            collaterals,
+            vec![instrument],
+            vec![bidask],
+        );
+        assert!(errors.is_empty());
+
+        // insert a position
+        let position = sample_position();
+        let insert_res = engine.insert_or_update_position(position).await;
+        assert!(insert_res.is_ok());
+
+        // update price
+        let new_price = MicroEngineBidask {
+            id: "EURUSD".to_string(),
+            bid: 1.2,
+            ask: 1.3,
+            base: "EUR".to_string(),
+            quote: "USD".to_string(),
+        };
+        engine.handle_new_price(vec![new_price]).await;
+
+        let (acc_updates, pos_updates) = engine.recalculate_accordint_to_updates().await;
+        assert!(acc_updates.is_empty());
+        assert_eq!(pos_updates.len(), 1);
+        assert_eq!(pos_updates[0].position_id, "POS1");
+
+        // ensure updates cleared
+        let (acc_updates2, pos_updates2) = engine.recalculate_accordint_to_updates().await;
+        assert!(acc_updates2.is_empty());
+        assert!(pos_updates2.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- update dependencies to allow `tokio::test`
- add helper functions and async tests for `MicroEngine`

## Testing
- `cargo fmt -- --check`
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_688a31d45a608320893898df9ca22fce